### PR TITLE
Fatal error: concurrent map writes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ go: 1.1
 script: make test
 before_install:
   - cd
-  - wget https://leveldb.googlecode.com/files/leveldb-1.10.0.tar.gz
-  - tar xzf leveldb-1.10.0.tar.gz
-  - cd leveldb-1.10.0
+  - wget https://github.com/google/leveldb/archive/v1.10.tar.gz
+  - tar xzf v1.10.tar.gz
+  - cd leveldb-1.10
   - make
   - export CGO_CFLAGS="-I`pwd`/include"
   - export CGO_LDFLAGS="-L`pwd`"

--- a/queued/memory_store.go
+++ b/queued/memory_store.go
@@ -1,5 +1,9 @@
 package queued
 
+import (
+	"sync"
+)
+
 // Iterator
 
 type MemoryIterator struct {
@@ -14,6 +18,7 @@ func (it *MemoryIterator) NextRecord() (*Record, bool) {
 type MemoryStore struct {
 	id      int
 	records map[int]*Record
+	mutex   sync.Mutex
 }
 
 func NewMemoryStore() *MemoryStore {
@@ -26,6 +31,9 @@ func NewMemoryStore() *MemoryStore {
 }
 
 func (s *MemoryStore) Get(id int) (*Record, error) {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	if record, ok := s.records[id]; ok {
 		return record, nil
 	} else {
@@ -34,6 +42,9 @@ func (s *MemoryStore) Get(id int) (*Record, error) {
 }
 
 func (s *MemoryStore) Put(record *Record) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	record.Id = s.id + 1
 	s.records[record.Id] = record
 	s.id = record.Id
@@ -41,6 +52,9 @@ func (s *MemoryStore) Put(record *Record) error {
 }
 
 func (s *MemoryStore) Remove(id int) error {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
 	delete(s.records, id)
 	return nil
 }


### PR DESCRIPTION
Hi, 
I was having a look at queued and decided to run some quick performance test. It have crashed very quickly . 
I am attaching the panic error log.  
[stderr.txt](https://github.com/scttnlsn/queued/files/627351/stderr.txt)

The command i ran was : 
`queued -store memory`
I used wrk to benchmark it: 
`wrk -c 512 -t 1 -d 10 -s wrk.queue.post.lua  http://127.0.0.1:5353/testqueue`
where the `wrk.queue.post.lua` did set the method and body : 
```
wrk.method = "POST"
wrk.body = "TEST_ELEMENT"
```

